### PR TITLE
increase test timeout

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -84,6 +84,9 @@ const config: HardhatUserConfig = {
     outDir: "typechain",
     target: "ethers-v5",
   },
+  mocha: {
+    timeout: 30000,
+  },
 };
 
 export default config;


### PR DESCRIPTION
While running the tests I got a timeout. The default is 20 seconds. I increased it to 30 seconds, maybe it should be even higher.