### PR TITLE
LDO token removal

### DIFF
--- a/contracts/1_ethereum/2_lido.fi/LidoAdapter.sol
+++ b/contracts/1_ethereum/2_lido.fi/LidoAdapter.sol
@@ -132,8 +132,8 @@ contract LidoAdapter is IAdapter {
      */
     function getDepositSomeCodes(
         address payable _vault,
-        address _underlyingToken,
-        address _liquidityPool,
+        address,
+        address,
         uint256 _amount
     ) public view override returns (bytes[] memory _codes) {
         if (_amount > 0) {
@@ -151,8 +151,8 @@ contract LidoAdapter is IAdapter {
      */
     function getWithdrawSomeCodes(
         address payable _vault,
-        address _underlyingToken,
-        address _liquidityPool,
+        address,
+        address,
         uint256 _amount
     ) public view override returns (bytes[] memory _codes) {
         if (_amount > 0) {

--- a/contracts/1_ethereum/2_lido.fi/LidoAdapter.sol
+++ b/contracts/1_ethereum/2_lido.fi/LidoAdapter.sol
@@ -229,6 +229,6 @@ contract LidoAdapter is IAdapter {
      * @inheritdoc IAdapter
      */
     function getRewardToken(address) public view override returns (address) {
-        return rewardToken;
+        return address(0);
     }
 }

--- a/contracts/1_ethereum/convex.finance/ConvexFinanceAdapter.sol
+++ b/contracts/1_ethereum/convex.finance/ConvexFinanceAdapter.sol
@@ -530,7 +530,7 @@ contract ConvexFinanceAdapter is IAdapter, IAdapterHarvestReward, IAdapterStakin
      */
     function getWithdrawSomeCodes(
         address payable,
-        address _underlyingToken,
+        address,
         address _liquidityPool,
         uint256 _shares
     ) public view override returns (bytes[] memory _codes) {

--- a/test/1_ethereum/lido.fi/LidoAdapter.behavior.ts
+++ b/test/1_ethereum/lido.fi/LidoAdapter.behavior.ts
@@ -104,7 +104,7 @@ export function shouldBehaveLikeLidoAdapter(token: string, pool: PoolItem): void
   it(`should return the reward token and assert that staking is not enabled`, async function () {
     // assert reward token
     const actualRewardToken = await this.lidoAdapter.getRewardToken(pool.pool);
-    expect(actualRewardToken).to.be.eq((pool.rewardTokens as string[])[0]);
+    expect(actualRewardToken).to.be.eq(hre.ethers.constants.AddressZero);
     // assert cannot stake
     const actualCanStake = await this.lidoAdapter.canStake(pool.pool);
     expect(actualCanStake).to.be.false;


### PR DESCRIPTION
Fixes #17 

Removed LDO token address from Lido's reward token since LDO is only a governance token and it is not distributed after depositing.

#### PR Checklist

- [ ] Tests
